### PR TITLE
Correct the license ids used in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,10 @@
 {
   "name": "octicons",
   "description": "GitHub's icon font",
-  "license": "SIL OFL 1.1, MIT",
+  "license": [
+    "OFL-1.1",
+    "MIT"
+  ],
   "homepage": "https://octicons.github.com",
   "authors": [
     "GitHub <support@github.com>"


### PR DESCRIPTION
The bower.json spec [says that the license field](https://github.com/bower/bower.json-spec#license) should use [SPDX license identifiers](https://github.com/bower/bower.json-spec), so it turns out the correct license ids for Octicons are [`OFL-1.1`](https://spdx.org/licenses/OFL-1.1.html) and [`MIT`](https://spdx.org/licenses/MIT.html).

The current license text isn't recognised by automated tools like the on-demand [Bower WebJar](http://www.jamesward.com/2015/03/23/scaling-the-webjars-project-with-on-demand-bower-packages) generator, which blocks the distribution: https://github.com/webjars/webjars/issues/984