### PR TITLE
Fix `package.json` to match `bower.json` licensing

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "icon font"
   ],
   "author": "GitHub <support@github.com>",
-  "license": "OFL-1.1 AND MIT",
+  "license": "(OFL-1.1 AND MIT)",
   "bugs": {
     "url": "https://github.com/github/octicons/issues"
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "icon font"
   ],
   "author": "GitHub <support@github.com>",
-  "license": "SIL OFL 1.1, MIT",
+  "license": "OFL-1.1 AND MIT",
   "bugs": {
     "url": "https://github.com/github/octicons/issues"
   },


### PR DESCRIPTION
* Post fix from #49

Applies to #45 when completed

See also:
* [https://docs.npmjs.com/files/package.json#license](https://docs.npmjs.com/files/package.json#license) ... note deprecation of plural form
* [SPDX license expressions](http://wiki.spdx.org/view/LicenseExpressionFAQ)
* [SPDX license expressions Examples](http://wiki.spdx.org/view/FileNoticeExamples)

Note(s):
* Interesting that the newer specification doesn't seem to exist for custom MIT licensing terms which are part of that specification and a few other license types e.g. not fixed format with the `url` property seeming to be missing for pointing to the [LICENSE content](https://github.com/github/octicons/blob/master/LICENSE.txt)... although usually extra properties in `package.json` are ignored