### PR TITLE
Add sketch-octicons to Resources section

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Octicons includes a stylesheet specifically for [Rails 4/Sprockets][sprockets].
     content_tag :span, '', :class => "octicon octicon-#{code.to_s.dasherize}"
   end
   ```
-  
+
 ## Installing locally
 
 It's easy to install octicons locally if you have [Homebrew](http://brew.sh/) installed. Simply run the following commands:
@@ -112,7 +112,8 @@ brew cask install "font-octicons"
 - [octicons.github.com](http://octicons.github.com/) - the Octicons website
 - Read why [icon fonts are awesome](http://css-tricks.com/examples/IconFont/)
 - How to compose your [HTML for icon font usage](http://css-tricks.com/html-for-icon-font-usage/)
-  
+- [sketch-octicons](https://github.com/JuanitoFatas/sketch-octicons) - Octicons icons as Sketch Symbols
+
 ## Why can't I see the characters in Font Book??
 
 Give this a try, you should be all set:


### PR DESCRIPTION
This Pull Request adds [sketch-octicons](https://github.com/JuanitoFatas/sketch-octicons), a collection of Octicons icons as [Sketch](https://sketchapp.com) Symbols, to Resources section.